### PR TITLE
Suggestion of Jim

### DIFF
--- a/src/components/asset-details/offers/PurchaseOfferAmount.vue
+++ b/src/components/asset-details/offers/PurchaseOfferAmount.vue
@@ -68,7 +68,10 @@ export default {
   },
   mounted () {
     this.minimumOffer = this.offerData.minimumOffer
-    this.offerAmount = this.offerData.offerAmount
+    this.offerAmount = this.offerData.offerAmount + 500
+    if (this.offerData.offerAmount > 20000) {
+      this.offerAmount = this.offerData.offerAmount + 1000
+    }
     this.offerAmountFiat = utils.toDecimals(this.currentRate.stxPrice * this.offerData.offerAmount)
     this.$emit('updateSaleDataInfo', { field: 'saleType', value: 3 })
     this.loading = false


### PR DESCRIPTION
Is it easy to change the Make Offer input amount box default to asking for a price $1000 above the current offer rather than the same price forcing users to type themselves? This might encourage more offers in round numbers if it just prompts them to bid in increments of $1k by always suggesting $1k above the current highest offer.

I said to Thomas if it's easy to change maybe we make it $500 and if we get offers over $20k we can change it to $1000 above the current offer.